### PR TITLE
Fix: Register IRankFusionService in DI container

### DIFF
--- a/src/FluxIndex.SDK/FluxIndexContextBuilder.cs
+++ b/src/FluxIndex.SDK/FluxIndexContextBuilder.cs
@@ -416,6 +416,7 @@ public class FluxIndexContextBuilder
         // Register hybrid search services
         _services.AddScoped<ISparseRetriever, BM25SparseRetriever>();
         _services.AddScoped<IHybridSearchService, HybridSearchService>();
+        _services.AddScoped<IRankFusionService, RankFusionService>();
 
         // Register Small-to-Big services
         _services.AddScoped<ISmallToBigRetriever, SmallToBigRetriever>();


### PR DESCRIPTION
- Add RankFusionService registration to FluxIndexContextBuilder
- Fixes NullReferenceException in HybridSearchAsync when using RRF fusion
- HybridSearch legacy API now works correctly with proper service registration

Issue: HybridSearchAsync was failing with NullReferenceException because IRankFusionService was not registered in the DI container, even though Retriever constructor expected it as an optional dependency.

Solution: Register RankFusionService as scoped service alongside other hybrid search services (ISparseRetriever, IHybridSearchService).

Impact: Enables HybridSearchAsync legacy API to work with both:
- RRF (Reciprocal Rank Fusion) when vectorWeight = 0.5
- Weighted fusion for other weight values

Note: HybridSearchV2Async already works correctly as it uses IHybridSearchService which was properly registered.